### PR TITLE
Cas 6.0.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,32 +43,32 @@ Ajouter la dépendance dans pom.xml de cas-overlay-template (https://github.com/a
 
 ## Configuration dans CAS
 
-Vous devez configurer dans cas-overlay-template\etc\cas\config\cas.properties les informations suivantes :
+Vous devez configurer dans /etc/cas/config/agimus.properties les informations suivantes :
 
-	cas.agimus.cookieName=AGIMUS
-	cas.agimus.cookieMaxAge=259200
-	cas.agimus.cookiePath=/
-	cas.agimus.cookieValueMaxLength=10
-	cas.agimus.cookieDomain=univ.fr
-	cas.agimus.cookieValuePrefix=TRACEAGIMUS
-	cas.agimus.traceFileSeparator=:
+	agimus.cookieName=AGIMUS
+	agimus.cookieMaxAge=259200
+	agimus.cookiePath=/
+	agimus.cookieValueMaxLength=10
+	agimus.cookieDomain=univ.fr
+	agimus.cookieValuePrefix=TRACEAGIMUS
+	agimus.traceFileSeparator=:
 	
 Sachant que :
  
  - cookieName : est le nom du cookie qui sera déposé sur le poste client
  - cookieMaxAge : délai de vie du cookie sur le poste client (3jours)
  - cookiePath : chemin d'où le cookie sera lisible
- - cas.agimus.cookieValueMaxLength : longueur maximum de la valeur du cookie
+ - cookieValueMaxLength : longueur maximum de la valeur du cookie
  - cookieDomain : nom du domain d'où le cookie sera lisible (attention le domaine ne doit pas commencer par un .)
  - cookieValuePrefix : prefix utiliser pour générer la valeur du cookie
  - traceFileSeparator : séparateur utilisé pour la génération du fichier (entre la valeur du cookie et l'identifiant utilisateur)
  
 Le cookie déposé sera la forme : 
-	{cas.agimus.cookieName} = {cas.agimus.cookieValuePrefix}-XXXXXXXXXX-{cas.host.name} 
+	{agimus.cookieName} = {agimus.cookieValuePrefix}-XXXXXXXXXX-{cas.host.name} 
 
 ## Gestion des logs
 
-Ajouter le logger dans cas-overlay-template/etc/cas/config/log4j2.xml
+Ajouter le logger dans /etc/cas/config/log4j2.xml
 
     <Appenders>
 		...

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.esupportail.cas</groupId>
   <artifactId>cas-server-support-agimus-cookie</artifactId>
-  <version>5.2.2</version>
+  <version>6.0.2</version>
   <packaging>jar</packaging>
   <build>
     <sourceDirectory>src</sourceDirectory>
@@ -28,17 +28,17 @@
 		</dependency>			
 		<dependency>
 			<groupId>org.apereo.cas</groupId>
-			<artifactId>cas-server-core-webflow</artifactId>
+			<artifactId>cas-server-core-webflow-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apereo.cas</groupId>
-			<artifactId>cas-server-core-web</artifactId>
+			<artifactId>cas-server-core-web-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apereo.cas</groupId>
-			<artifactId>cas-server-support-cookie</artifactId>
+			<artifactId>cas-server-core-cookie-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.esupportail.cas</groupId>
   <artifactId>cas-server-support-agimus-cookie</artifactId>
-  <version>6.0.2</version>
+  <version>6.0.3</version>
   <packaging>jar</packaging>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.esupportail.cas</groupId>
   <artifactId>cas-server-support-agimus-cookie</artifactId>
-  <version>6.0.3</version>
+  <version>6.0.8.1</version>
   <packaging>jar</packaging>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/src/main/java/org/esupportail/cas/config/CasAgimusConfigurationProperties.java
+++ b/src/main/java/org/esupportail/cas/config/CasAgimusConfigurationProperties.java
@@ -2,13 +2,15 @@ package org.esupportail.cas.config;
 
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
 
 /**
  * CAS Agimus configuration properties model.
  *
  * @author Julien Marchal
  */
-@ConfigurationProperties(prefix = "cas.agimus")
+@PropertySource(ignoreResourceNotFound = true, value={"classpath:agimus.properties", "file:/var/cas/config/agimus.properties", "file:/opt/cas/config/agimus.properties", "file:/etc/cas/config/agimus.properties", "file:${cas.standalone.configurationDirectory}/agimus.properties"})
+@ConfigurationProperties(prefix = "agimus", ignoreUnknownFields = false)
 public class CasAgimusConfigurationProperties {
     private String cookieName = "AGIMUS";
     // 3 days

--- a/src/main/java/org/esupportail/cas/config/CasAgimusCookieWebflowConfiguration.java
+++ b/src/main/java/org/esupportail/cas/config/CasAgimusCookieWebflowConfiguration.java
@@ -2,9 +2,10 @@ package org.esupportail.cas.config;
 
 import org.apereo.cas.authentication.adaptive.AdaptiveAuthenticationPolicy;
 import org.apereo.cas.configuration.CasConfigurationProperties;
-import org.apereo.cas.ticket.UniqueTicketIdGenerator;
 import org.apereo.cas.util.HostNameBasedUniqueTicketIdGenerator;
 import org.apereo.cas.web.flow.CasWebflowConfigurer;
+import org.apereo.cas.web.flow.CasWebflowExecutionPlan;
+import org.apereo.cas.web.flow.CasWebflowExecutionPlanConfigurer;
 import org.apereo.cas.web.flow.resolver.CasDelegatingWebflowEventResolver;
 import org.apereo.cas.web.flow.resolver.CasWebflowEventResolver;
 import org.apereo.cas.web.support.CookieRetrievingCookieGenerator;
@@ -14,8 +15,10 @@ import org.esupportail.cas.util.CasAgimusLogger;
 import org.esupportail.cas.web.AgimusCookieRetrievingCookieGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ApplicationContext;
@@ -34,20 +37,20 @@ import org.springframework.webflow.execution.Action;
  */
 @Configuration("casAgimusCookieWebflowConfiguration")
 @EnableConfigurationProperties(CasConfigurationProperties.class)
-public class CasAgimusCookieWebflowConfiguration {
+public class CasAgimusCookieWebflowConfiguration implements CasWebflowExecutionPlanConfigurer {
 	private static final Logger LOGGER = LoggerFactory.getLogger(CasAgimusCookieWebflowConfiguration.class);
    	
 	@Autowired
-    @Qualifier("adaptiveAuthenticationPolicy")
-    private AdaptiveAuthenticationPolicy adaptiveAuthenticationPolicy;
-
-    @Autowired
-    @Qualifier("serviceTicketRequestWebflowEventResolver")
-    private CasWebflowEventResolver serviceTicketRequestWebflowEventResolver;
-
-    @Autowired
-    @Qualifier("initialAuthenticationAttemptWebflowEventResolver")
-    private CasDelegatingWebflowEventResolver initialAuthenticationAttemptWebflowEventResolver;
+	@Qualifier("adaptiveAuthenticationPolicy")
+	private ObjectProvider<AdaptiveAuthenticationPolicy> adaptiveAuthenticationPolicy;
+	
+	@Autowired
+	@Qualifier("serviceTicketRequestWebflowEventResolver")
+	private ObjectProvider<CasWebflowEventResolver> serviceTicketRequestWebflowEventResolver;
+	
+	@Autowired
+	@Qualifier("initialAuthenticationAttemptWebflowEventResolver")
+	private ObjectProvider<CasDelegatingWebflowEventResolver> initialAuthenticationAttemptWebflowEventResolver;
 
     @Autowired
     private ApplicationContext applicationContext;
@@ -56,8 +59,11 @@ public class CasAgimusCookieWebflowConfiguration {
     private CasConfigurationProperties casProperties;
     
     @Autowired
+    private CasAgimusConfigurationProperties casAgimusConfigurationProperties;
+    
+    @Autowired
     @Qualifier("loginFlowRegistry")
-    private FlowDefinitionRegistry loginFlowDefinitionRegistry;
+    private ObjectProvider<FlowDefinitionRegistry> loginFlowDefinitionRegistry;
 
     @Autowired
     private FlowBuilderServices flowBuilderServices;
@@ -65,38 +71,31 @@ public class CasAgimusCookieWebflowConfiguration {
     @Autowired
     @Qualifier("agimusTokenTicketIdGenerator")
     private HostNameBasedUniqueTicketIdGenerator agimusTokenTicketIdGenerator;
-
-    
-    @Bean
-    @RefreshScope
-    public CasAgimusConfigurationProperties agimusConfigurationProperties() {
-        return new CasAgimusConfigurationProperties();
-    }
     
     @Bean
     @RefreshScope
     public HostNameBasedUniqueTicketIdGenerator agimusTokenTicketIdGenerator() {
         /*return new DefaultUniqueTicketIdGenerator();*/
     	return new HostNameBasedUniqueTicketIdGenerator(
-    				agimusConfigurationProperties().getCookieValueMaxLength(),
+    				casAgimusConfigurationProperties.getCookieValueMaxLength(),
     				casProperties.getHost().getName()
     			);
     }
-
-    @Bean
-    public CasAgimusLogger agimusLogger() {
-    	LOGGER.debug("CasAgimusCookieWebflowConfiguration::CasAgimusLogger : Create bean agimusLogger");    	
     
-        return new CasAgimusLogger();
-    }
+   @Bean
+   public CasAgimusLogger agimusLogger() {
+      	LOGGER.debug("CasAgimusCookieWebflowConfiguration::CasAgimusLogger : Create bean agimusLogger");        
+      	return new CasAgimusLogger(casAgimusConfigurationProperties);
+   }
+
     
     @Bean
     public Action agimusCookieAction() {
     	LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieAction : Create bean agimusCookieAction");    	
     
-        return new AgimusCookieAction(initialAuthenticationAttemptWebflowEventResolver, 
-                serviceTicketRequestWebflowEventResolver,
-                adaptiveAuthenticationPolicy);
+        return new AgimusCookieAction(initialAuthenticationAttemptWebflowEventResolver.getIfAvailable(), 
+                serviceTicketRequestWebflowEventResolver.getIfAvailable(),
+                adaptiveAuthenticationPolicy.getIfAvailable(), casAgimusConfigurationProperties);
     }
     
     @Bean
@@ -105,32 +104,35 @@ public class CasAgimusCookieWebflowConfiguration {
     	LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : Create bean agimusCookieGenerator");
     	LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : Read Properties");
     	
-    	CasAgimusConfigurationProperties agimusConfigurationProperties = this.agimusConfigurationProperties();
-    	
 
-    	LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookieName = ["+ agimusConfigurationProperties.getCookieName() +"]");                        
-        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookieMaxAge = ["+ agimusConfigurationProperties.getCookieMaxAge() +"]");
-        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookiePath = ["+ agimusConfigurationProperties.getCookiePath() +"]");
-        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookieDomain = ["+ agimusConfigurationProperties.getCookieDomain() +"]");
-        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookieValuePrefix = ["+ agimusConfigurationProperties.getCookieValuePrefix() +"]");
-        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusTraceFileSeparator = ["+ agimusConfigurationProperties.getTraceFileSeparator() +"]");
+    	LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookieName = ["+ casAgimusConfigurationProperties.getCookieName() +"]");                        
+        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookieMaxAge = ["+ casAgimusConfigurationProperties.getCookieMaxAge() +"]");
+        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookiePath = ["+ casAgimusConfigurationProperties.getCookiePath() +"]");
+        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookieDomain = ["+ casAgimusConfigurationProperties.getCookieDomain() +"]");
+        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusCookieValuePrefix = ["+ casAgimusConfigurationProperties.getCookieValuePrefix() +"]");
+        LOGGER.debug("CasAgimusCookieWebflowConfiguration::agimusCookieGenerator : AgimusTraceFileSeparator = ["+ casAgimusConfigurationProperties.getTraceFileSeparator() +"]");
         
-    	return new AgimusCookieRetrievingCookieGenerator(agimusConfigurationProperties.getCookieName(), 
-    			agimusConfigurationProperties.getCookiePath(), 
-    			agimusConfigurationProperties.getCookieMaxAge(),
-    			agimusConfigurationProperties.getCookieDomain(),
-    			agimusConfigurationProperties.getCookieValuePrefix());
+    	return new AgimusCookieRetrievingCookieGenerator(casAgimusConfigurationProperties.getCookieName(), 
+    			casAgimusConfigurationProperties.getCookiePath(), 
+    			casAgimusConfigurationProperties.getCookieMaxAge(),
+    			casAgimusConfigurationProperties.getCookieDomain(),
+    			casAgimusConfigurationProperties.getCookieValuePrefix());
     }
     
+    @ConditionalOnMissingBean(name = "agimusCookieWebflowConfigurer")
     @Bean
-    @DependsOn("defaultWebflowConfigurer")
+    @RefreshScope
     public CasWebflowConfigurer agimusCookieWebflowConfigurer() {
     	LOGGER.info("CasAgimusCookieWebflowConfiguration::agimusCookieWebflowConfigurer : configure Agimus WebFlow");    
-    	final CasWebflowConfigurer w = new AgimusCookieWebflowConfigurer(flowBuilderServices,          
-                loginFlowDefinitionRegistry,
+    	return new AgimusCookieWebflowConfigurer(flowBuilderServices,          
+                loginFlowDefinitionRegistry.getIfAvailable(),
                 applicationContext, casProperties);
-        w.initialize();
-        return w;
     }   
+    
+    @Override
+    public void configureWebflowExecutionPlan(final CasWebflowExecutionPlan plan) {
+    	plan.registerWebflowConfigurer(agimusCookieWebflowConfigurer());
+    }
+
     
 }

--- a/src/main/java/org/esupportail/cas/flow/AgimusCookieAction.java
+++ b/src/main/java/org/esupportail/cas/flow/AgimusCookieAction.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.webflow.execution.RequestContext;
 /**
  * This is {@link AgimusCookieAction} that extracts basic authN credentials from the request.
@@ -28,8 +29,6 @@ import org.springframework.webflow.execution.RequestContext;
 public class AgimusCookieAction extends AbstractNonInteractiveCredentialsAction {
     private static final Logger LOGGER = LoggerFactory.getLogger(AgimusCookieAction.class);
     
-    @Autowired
-    @Qualifier("agimusConfigurationProperties")
     private CasAgimusConfigurationProperties agimusConfigurationProperties;
     
     @Autowired
@@ -46,8 +45,9 @@ public class AgimusCookieAction extends AbstractNonInteractiveCredentialsAction 
     
     public AgimusCookieAction(final CasDelegatingWebflowEventResolver initialAuthenticationAttemptWebflowEventResolver,
                                      final CasWebflowEventResolver serviceTicketRequestWebflowEventResolver,
-                                     final AdaptiveAuthenticationPolicy adaptiveAuthenticationPolicy) {    	
+                                     final AdaptiveAuthenticationPolicy adaptiveAuthenticationPolicy, CasAgimusConfigurationProperties casAgimusConfigurationProperties) {    	
     	super(initialAuthenticationAttemptWebflowEventResolver, serviceTicketRequestWebflowEventResolver, adaptiveAuthenticationPolicy);
+    	this.agimusConfigurationProperties = casAgimusConfigurationProperties;
     	LOGGER.debug("AgimusCookieAction::AgimusCookieAction : create bean AgimusCookieAction");
     }
 

--- a/src/main/java/org/esupportail/cas/flow/AgimusCookieAction.java
+++ b/src/main/java/org/esupportail/cas/flow/AgimusCookieAction.java
@@ -79,6 +79,6 @@ public class AgimusCookieAction extends AbstractNonInteractiveCredentialsAction 
         } catch (final Exception e) {
             LOGGER.warn(e.getMessage(), e);
         }
-        return null;
+        return WebUtils.getCredential(requestContext);
     }
 }

--- a/src/main/java/org/esupportail/cas/flow/AgimusCookieWebflowConfigurer.java
+++ b/src/main/java/org/esupportail/cas/flow/AgimusCookieWebflowConfigurer.java
@@ -37,7 +37,7 @@ public class AgimusCookieWebflowConfigurer extends AbstractCasWebflowConfigurer 
         	LOGGER.debug("AgimusCookieWebflowConfigurer::doInitialize : Add agimusCookieAction in WebFlow");
         	
         	final ActionState actionState = getState(flow, CasWebflowConstants.STATE_ID_GENERATE_SERVICE_TICKET, ActionState.class);
-            actionState.getEntryActionList().add(createEvaluateAction("agimusCookieAction"));
+        	actionState.getEntryActionList().add(createEvaluateAction("agimusCookieAction"));
         }
     }
     

--- a/src/main/java/org/esupportail/cas/util/CasAgimusLogger.java
+++ b/src/main/java/org/esupportail/cas/util/CasAgimusLogger.java
@@ -3,8 +3,6 @@ package org.esupportail.cas.util;
 import org.esupportail.cas.config.CasAgimusConfigurationProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
  * This is {@link CasAgimusLogger}.
@@ -15,12 +13,11 @@ import org.springframework.beans.factory.annotation.Qualifier;
 public class CasAgimusLogger {
 	private static final Logger LOGGER = LoggerFactory.getLogger(CasAgimusLogger.class);
    
-	@Autowired
-    @Qualifier("agimusConfigurationProperties")
     private CasAgimusConfigurationProperties agimusConfigurationProperties;
     
-	public CasAgimusLogger() {		
+	public CasAgimusLogger(CasAgimusConfigurationProperties casAgimusConfigurationProperties) {		
 		LOGGER.debug("CasAgimusLogger::CasAgimusLogger : create bean CasAgimusLogger");    	
+		this.agimusConfigurationProperties= casAgimusConfigurationProperties;
 	}
 	
 	public void log(String username, String value) {

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,2 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.esupportail.cas.config.CasAgimusCookieWebflowConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.esupportail.cas.config.CasAgimusCookieWebflowConfiguration,\
+org.esupportail.cas.config.CasAgimusConfigurationProperties


### PR DESCRIPTION
Modifications pour supporter la 6.0.3 version de CAS ; j'ai testé avec le 6.0.3-SNAPSHOT :+1:  la 6.0.3 vient de sortir en fait.
Je pense qu'on ne peut pas garder la configuration dans un fichier cas.properties, et surtout pas avec le préfixe cas. d'où ces modifications, cf le README.
-> à mettre sans doute dans une branche spécifique cas-6.0.x et à taguer ainsi je pense ?